### PR TITLE
feat(e2e): implement issue #10 - video and screenshot artifacts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,5 +8,10 @@ export default defineConfig({
   reporter: 'line',
   use: {
     trace: 'on-first-retry',
+    video: {
+      mode: 'on',
+      size: { width: 1280, height: 800 }
+    },
+    screenshot: 'on'
   },
 });

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -60,6 +60,10 @@ test('Discrub extension - Quick Export TXT end-to-end', async () => {
   const userDataDir = path.resolve(os.tmpdir(), 'test-user-data-dir');
   const context = await chromium.launchPersistentContext(userDataDir, {
     headless: false,
+    recordVideo: {
+      dir: path.resolve(__dirname, '../test-results/videos'),
+      size: { width: 1280, height: 800 },
+    },
     args: [
       `--disable-extensions-except=${extensionPath}`,
       `--load-extension=${extensionPath}`,


### PR DESCRIPTION
Implements Issue #10.

This PR adds video and screenshot artifact capture to the Playwright E2E test suite. 

**Changes:**
- Updated  to enable video and screenshot capture.
- Patched  to explicitly enable  in the persistent context.
- Verified functionality by running the Quick Export TXT test, which passed successfully.

**Proof of Work:**
- E2E Test Video: [Attached to issue/comment]
- Quick Export TXT Snippet:
```text
[2/22/2026, 11:00:59 AM] melon-claw-bot: I hate to break it to you, but I just woke up. Literally.
...
```